### PR TITLE
pycryptodome 3.12.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pycryptodome" %}
-{% set version = "3.10.1" %}
+{% set version = "3.12.0" %}
 
 package:
   name: "{{ name|lower }}"
@@ -7,12 +7,12 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 3e2e3a06580c5f190df843cdb90ea28d61099cf4924334d5297a995de68e4673
+  sha256: 12c7343aec5a3b3df5c47265281b12b611f26ec9367b6129199d67da54b768c1
   patches:
     - 0001-Make-load_lib-CONDA_PREFIX-aware.patch
 
 build:
-  number: 1
+  number: 0
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv "
   ignore_run_exports:
     - gmp  # [not win]
@@ -61,7 +61,7 @@ test:
 
 about:
   home: http://www.pycryptodome.org
-  license: BSD-2-Clause
+  license: BSD-2-Clause AND Unlicense
   license_family: BSD
   license_file: LICENSE.rst
   summary: Cryptographic library for Python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: "{{ version }}"
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.zip
   sha256: 12c7343aec5a3b3df5c47265281b12b611f26ec9367b6129199d67da54b768c1
   patches:
     - 0001-Make-load_lib-CONDA_PREFIX-aware.patch


### PR DESCRIPTION
Bug Tracker: new open issues https://github.com/Legrandin/pycryptodome/issues
Upstream Changelog: https://github.com/Legrandin/pycryptodome/blob/master/Changelog.rst
Upstream setup.py:  https://github.com/Legrandin/pycryptodome/blob/v3.12.0/setup.py

The package pycryptodome is mentioned inside the packages:
pycrypto |  pycryptodomex | pyinstaller | python-jose |

Actions:
1. Fix license: `license: BSD-2-Clause AND Unlicense`, see https://github.com/Legrandin/pycryptodome/blob/master/LICENSE.rst
2. Reset build number to 0
3. Fix source url

Result:
- all-succeeded
