### PR TITLE
pycryptodome 3.15.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.zip
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 9135dddad504592bcc18b0d2d95ce86c3a5ea87ec6447ef25cfedea12d6018b8
   patches:
     - 0001-Make-load_lib-CONDA_PREFIX-aware.patch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,21 +1,22 @@
 {% set name = "pycryptodome" %}
-{% set version = "3.12.0" %}
+{% set version = "3.15.0" %}
 
 package:
-  name: "{{ name|lower }}"
-  version: "{{ version }}"
+  name: {{ name|lower }}
+  version: {{ version }}
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.zip
-  sha256: 12c7343aec5a3b3df5c47265281b12b611f26ec9367b6129199d67da54b768c1
+  sha256: 9135dddad504592bcc18b0d2d95ce86c3a5ea87ec6447ef25cfedea12d6018b8
   patches:
     - 0001-Make-load_lib-CONDA_PREFIX-aware.patch
 
 build:
   number: 0
-  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
   ignore_run_exports:
     - gmp  # [not win]
+
 requirements:
   build:
     - {{ compiler('c') }}
@@ -31,6 +32,7 @@ requirements:
   run:
     - python
     - gmp   # [not win]
+
 test:
   requires:
     - pytest
@@ -60,7 +62,7 @@ test:
     - Crypto.Util
 
 about:
-  home: http://www.pycryptodome.org
+  home: https://www.pycryptodome.org
   license: BSD-2-Clause AND Unlicense
   license_family: BSD
   license_file: LICENSE.rst


### PR DESCRIPTION
The current version 3.12.0 has a missing artifact for python 3.10 on linux-64

License: https://github.com/Legrandin/pycryptodome/blob/v3.15.0/LICENSE.rst
Changelog: https://github.com/Legrandin/pycryptodome/blob/v3.15.0/Changelog.rst
Requierements: https://github.com/Legrandin/pycryptodome/blob/v3.15.0/setup.py



Actions:
1. Fix home url