### PR TITLE
Update recipe for py313_codesign

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pycryptodome" %}
-{% set version = "3.20.0" %}
+{% set version = "3.21.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,12 +7,12 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 09609209ed7de61c2b560cc5c8c4fbf892f8b15b1faf7e4cbffac97db1fffda7
+  sha256: f7787e0d469bdae763b876174cf2e6c0f7be79808af26b1da96f1a64bcf47297
   patches:
     - 0001-Make-load_lib-CONDA_PREFIX-aware.patch
 
 build:
-  number: 1
+  number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv --no-build-isolation
   ignore_run_exports:
     - gmp  # [not win]
@@ -69,7 +69,7 @@ about:
   summary: Cryptographic library for Python
   description: |
     PyCryptodome is a self-contained Python package of low-level cryptographic primitives. PyCryptodome is not a wrapper to a separate C library like OpenSSL. To the largest possible extent, algorithms are implemented in pure Python. Only the pieces that are extremely critical to performance (e.g. block ciphers) are implemented as C extensions.
-  doc_url: https://www.pycryptodome.org/en/latest/
+  doc_url: https://www.pycryptodome.org
   dev_url: https://github.com/Legrandin/pycryptodome
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 0001-Make-load_lib-CONDA_PREFIX-aware.patch
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv --no-build-isolation
   ignore_run_exports:
     - gmp  # [not win]


### PR DESCRIPTION
Rebuild for codesigned win-64 py313 artifacts.

updated to 3.21.0
https://github.com/Legrandin/pycryptodome/tree/v3.21.0