### PR TITLE
Update version to 3.23.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "pycryptodome" %}
-{% set version = "3.21.0" %}
+{% set version = "3.23.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: f7787e0d469bdae763b876174cf2e6c0f7be79808af26b1da96f1a64bcf47297
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 447700a657182d60338bab09fdb27518f8856aecd80ae4c6bdddb67ff5da44ef
   patches:
     - 0001-Make-load_lib-CONDA_PREFIX-aware.patch
 
@@ -19,16 +19,14 @@ build:
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
-    - m2-patch  # [win]
-    - patch  # [not win]
     - git    # [not win]
   host:
     - pip
     - python
     - gmp   # [not win]
     - setuptools
-    - wheel
   run:
     - python
     - gmp   # [not win]


### PR DESCRIPTION
pycryptodome 3.23.0

**Destination channel:** defaults

### Links

- [PKG-10969](https://anaconda.atlassian.net/browse/PKG-10969) 
- [Upstream repository](https://github.com/Legrandin/pycryptodome)

### Explanation of changes:

- New version number
- Update dependency


[PKG-10969]: https://anaconda.atlassian.net/browse/PKG-10969?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ